### PR TITLE
docs: adds contributing guide for Linux/MacOS users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Setup Node.js on your environment:
 
 Confirm your installation is successful by running the following command in your terminal:
 
-`node -v`
+* `node -v`  
 
 ### Setup `aws-cdk-library` on your Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,31 @@ To create a new test:
 Snapshots are created and stored in the `integ.example.ts.snapshot` directory and should be committed along with
 the rest of your code.
 
+## Linux/MacOS Environment Setup
+
+### Installation
+
+Setup Node.js on your environment:
+
+* [Node.js Install](https://nodejs.org/en/download/package-manager)
+
+Confirm your installation is successful by running the following command in your terminal:
+
+`node -v`
+
+### Setup `aws-cdk-library` on your Environment
+
+To contribute, fork the repository to your own GitHub account, and then clone it onto your machine:
+
+* `git clone https://github.com/<your_username_here>/aws-cdk-library.git`
+
+Open the project and confirm that your setup is working by running the following commands:
+
+* `npm install`  
+* `npm run build`  
+
+If it runs successfully, your environment is setup correctly.
+
 ## Windows Environment Setup
 
 Currently `projen` does not support Windows very well.


### PR DESCRIPTION
This PR adds documentation for Linux/MacOS users similar to the existing Windows documentation. (#17)

The documentation aims to guide contributors to setup their local environment to contribute to the `open-constructs/aws-cdk-library`.

To MacOS and Linux users, please confirm that it is correct, or if anything else is needed. I was only able to confirm on WSL that this is correct, but the process seems simple enough for Linux/MacOS.