### PR TITLE
docs: fix format in feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ assignees: ''
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-** Would you be willing to help with a PR? **
+**Would you be willing to help with a PR?**
 - [ ] Yes, absolutely
 - [ ] Yes, with some guidance
 - [ ] Unfortunately no time :'-(


### PR DESCRIPTION
### Issue # (if applicable)

No issue.

### Reason for this change

In markdown, bold text is only recognized if there is no space after the beginning `**` and before closing `**`. When you create a new feature request and open the preview, the headline `Would you be willing to help with a PR?` is not formatted as bold text.

### Description of changes

I removed the spaces.

### Description of how you validated changes

Preview mode when creating a new issue.

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
