### PR TITLE
fix(redshiftserverless): from method generates invalid ARN

### DIFF
--- a/src/aws-redshiftserverless/namespace.ts
+++ b/src/aws-redshiftserverless/namespace.ts
@@ -170,8 +170,8 @@ export class Namespace extends Resource implements INamespace {
       public readonly namespaceName = attrs.namespaceName;
       public readonly namespaceId = attrs.namespaceId;
       public readonly namespaceArn = Stack.of(this).formatArn({
-        resource: 'redshift-serverless',
-        service: 'namespace',
+        service: 'redshift-serverless',
+        resource: 'namespace',
         resourceName: attrs.namespaceId,
       });
     }

--- a/src/aws-redshiftserverless/workgroup.ts
+++ b/src/aws-redshiftserverless/workgroup.ts
@@ -180,8 +180,8 @@ export class Workgroup extends Resource implements IWorkgroup {
         defaultPort: aws_ec2.Port.tcp(attrs.port),
       });
       public readonly workgroupArn = Stack.of(this).formatArn({
-        resource: 'redshift-serverless',
-        service: 'workgroup',
+        service: 'redshift-serverless',
+        resource: 'workgroup',
         resourceName: attrs.workgroupId,
       });
     }

--- a/test/aws-redshiftserverless/namespace.test.ts
+++ b/test/aws-redshiftserverless/namespace.test.ts
@@ -77,8 +77,8 @@ describe('Redshift Serverless Namespace', () => {
     test('should correctly format namespaceArn', () => {
       expect(existingNamespace.namespaceArn).toEqual(
         Stack.of(stack).formatArn({
-          resource: 'redshift-serverless',
-          service: 'namespace',
+          service: 'redshift-serverless',
+          resource: 'namespace',
           resourceName: 'my-namespace-id',
         }),
       );

--- a/test/aws-redshiftserverless/workgroup.test.ts
+++ b/test/aws-redshiftserverless/workgroup.test.ts
@@ -119,8 +119,8 @@ describe('Redshift Serverless Workgroup', () => {
     test('should correctly format workgroupArn', () => {
       expect(importedWorkgroup.workgroupArn).toEqual(
         Stack.of(stack).formatArn({
-          resource: 'redshift-serverless',
-          service: 'workgroup',
+          service: 'redshift-serverless',
+          resource: 'workgroup',
           resourceName: 'my-workgroup-id',
         }),
       );


### PR DESCRIPTION
### Issue # (if applicable)
N/A

### Reason for this change
In the from method, the settings of service and resource are reversed, resulting in the generation of an invalid ARN.

<!--What is the bug or use case behind this change?-->

### Description of changes
Corrected the settings of service and resource properties.

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes
Fix unit tests.

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
