### PR TITLE
docs: add description for PR title rule in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,9 @@ Closes #<issue number here>.
 ### Checklist
 
 - [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)
+- [ ] My pull request adheres to the [Pull Request Rule](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md#pull-request)
+  - **Do not omit the `aws-` part in the scope of the PR title if the PR relates to a specific AWS service module.**
+  - e.g.) feat(**aws-s3**): description of the change
 
 ---
 _By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -52,7 +52,10 @@ Closes #<issue number here>.
 
 ### Checklist
 
-- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)`,
+- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)
+- [ ] My pull request adheres to the [Pull Request Rule](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md#pull-request)
+  - **Do not omit the \`aws-\` part in the scope of the PR title if the PR relates to a specific AWS service module.**
+  - e.g.) feat(**aws-s3**): description of the change`,
   ],
   releaseTrigger: release.ReleaseTrigger.continuous(),
   releasableCommits: ReleasableCommits.ofType(['feat', 'fix', 'revert', 'Revert']),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -252,7 +252,7 @@ When submitting a pull request, please ensure that you have followed the guideli
   * `fix`: Describe the bug (not the solution)
 * In the case of changes to a specific module, the scope of the title should include the name of that module.
   * e.g.) `feat(aws-s3): description of the change`
-  * Do not omit the `aws-` part.
+  * Do not omit the `aws-` part in the scope of the PR title if the PR relates to a specific AWS service module.
 * Formatting guidelines for titles:
   * Title should be lowercase (except for the special use of `Revert`).
   * Do not end the title with a period.


### PR DESCRIPTION
### Reason for this change

<!--What is the bug or use case behind this change?-->

In many cases, the `aws-` is forgotten in the scope of the PR title.

### Description of changes

<!--What code changes did you make? Have you made any important design decisions?-->

Added the description (as the checklist) in the PR template.

Some PRs are not specific scoped and therefore I don't (can't) check by custom lint. (Such as `chore(deps):` , `docs:`, `feat(other-provider-service):`, etc...)

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
