### PR TITLE
fix(aws-elasticache): incorrect user interface implementation in PasswordUser and NoPasswordRequiredUser classes

### DIFF
--- a/src/aws-elasticache/user.ts
+++ b/src/aws-elasticache/user.ts
@@ -331,7 +331,7 @@ export class PasswordUser extends BaseUser implements IPasswordUser {
    * Imports an existing password authentication user from attributes
    */
   public static fromUserAttributes(scope: Construct, id: string, attrs: PasswordUserAttributes): IPasswordUser {
-    class Import extends Resource implements IUser {
+    class Import extends Resource implements IPasswordUser {
       public readonly userId = attrs.userId;
       public readonly userName = attrs.userName;
       public readonly userArn = Stack.of(this).formatArn({
@@ -423,7 +423,7 @@ export class NoPasswordRequiredUser extends BaseUser implements INoPasswordRequi
     id: string,
     attrs: NoPasswordUserAttributes,
   ): INoPasswordRequiredUser {
-    class Import extends Resource implements IUser {
+    class Import extends Resource implements INoPasswordRequiredUser {
       public readonly userId = attrs.userId;
       public readonly userName = attrs.userName;
       public readonly userArn = Stack.of(this).formatArn({


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change
Changed the type implemented by the `Import` class because the return type of the `fromUserAttributes` method did not match the type the `Import` class was implementing.

### Description of changes

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)
- [x] My pull request adheres to the [Pull Request Rule](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md#pull-request)
  - **Do not omit the `aws-` part in the scope of the PR title if the PR relates to a specific AWS service module.**
  - e.g.) feat(**aws-s3**): description of the change

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
