### PR TITLE
docs(aws-elasticache): Add missing `new` keywords  in README

### DIFF
--- a/src/aws-elasticache/README.md
+++ b/src/aws-elasticache/README.md
@@ -12,7 +12,7 @@ This module has constructs for [Amazon ElastiCache](https://docs.aws.amazon.com/
 Setup required properties and create:
 
 ```ts
-const newDefaultUser = NoPasswordRequiredUser(this, 'DefaultUser', {
+const newDefaultUser = new NoPasswordRequiredUser(this, 'DefaultUser', {
   userName: 'default',
 });
 
@@ -46,7 +46,7 @@ For more information, see [Specifying Permissions Using an Access String](https:
 You can create an IAM-enabled user by using `IamUser` construct:
 
 ```ts
-const user = IamUser(this, 'User', {
+const user = new IamUser(this, 'User', {
   // set user id
   userId: 'my-user',
 
@@ -60,7 +60,7 @@ const user = IamUser(this, 'User', {
 If you want to create a password authenticated user, use `PasswordUser` construct:
 
 ```ts
-const user = PasswordUser(this, 'User', {
+const user = new PasswordUser(this, 'User', {
   // set user id
   userId: 'my-user-id',
 
@@ -81,7 +81,7 @@ const user = PasswordUser(this, 'User', {
 If the `passwords` property is not specified, a single password will be automatically generated and stored in AWS Secrets Manager.
 
 ```ts
-const user = PasswordUser(this, 'User', {
+const user = new PasswordUser(this, 'User', {
   userId: 'my-user-id',
   accessString: 'on ~* +@all',
   userName: 'my-user-name',
@@ -95,7 +95,7 @@ user.generatedSecret
 You can also create a no password required user by using `NoPasswordRequiredUser` construct:
 
 ```ts
-const user = NoPasswordRequiredUser(this, 'User', {
+const user = new NoPasswordRequiredUser(this, 'User', {
   // set user id
   userId: 'my-user-id',
 
@@ -132,7 +132,7 @@ const defaultUser = NoPasswordRequiredUser.fromUserAttributes(this, 'DefaultUser
 });
 
 // create a new default user
-const newDefaultUser = NoPasswordRequiredUser(this, 'NewDefaultUser', {
+const newDefaultUser = new NoPasswordRequiredUser(this, 'NewDefaultUser', {
   // new default user id must not be 'default'
   userId: 'new-default',
   // default username must be 'default'


### PR DESCRIPTION
### Issue # (if applicable)

N/A

### Reason for this change
The `new` keywords were missing when instantiating user classes in README. 😅
<!--What is the bug or use case behind this change?-->

### Description of changes
Added missing `new` keywords before user classes instantiations in README

<!--What code changes did you make? Have you made any important design decisions?-->

### Description of how you validated changes
Nothing
<!--Have you added any unit tests and/or integration tests?-->

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)
- [x] My pull request adheres to the [Pull Request Rule](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md#pull-request)
  - **Do not omit the `aws-` part in the scope of the PR title if the PR relates to a specific AWS service module.**
  - e.g.) feat(**aws-s3**): description of the change

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
