### PR TITLE
fix(aws-elasticache): fix endpointPort references in dependencies

### DIFF
--- a/src/aws-elasticache/serverless-cache.ts
+++ b/src/aws-elasticache/serverless-cache.ts
@@ -618,7 +618,7 @@ export class ServerlessCache extends ServerlessCacheBase {
     this.serverlessCacheName = serverlessCache.ref;
 
     this.endpointAddress = serverlessCache.attrEndpointAddress;
-    this.endpointPort = Number(serverlessCache.attrEndpointPort);
+    this.endpointPort = Token.asNumber(serverlessCache.attrEndpointPort);
 
     this.connections = new aws_ec2.Connections({
       securityGroups: this.securityGroups,


### PR DESCRIPTION
### Reason for this change

The ServerlessCache construct casts the underlying resource endpoint port to a number using the javascript Number constructor, which isn't properly handled when using the value in other resources. 

### Description of changes

The fix is to instead use `Token.asNumber` which properly registers the token and tracks dependencies.

### Description of how you validated changes

Added a unit test to verify the value across stacks.

### Checklist

- [X] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md)
- [X] My pull request adheres to the [Pull Request Rule](https://github.com/open-constructs/aws-cdk-library/blob/main/CONTRIBUTING.md#pull-request)
  - **Do not omit the `aws-` part in the scope of the PR title if the PR relates to a specific AWS service module.**
  - e.g.) feat(**aws-s3**): description of the change

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
